### PR TITLE
Make `platform-test-lib` a `devDependency`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@textshq/eslint-config": "https://github.com/TextsHQ/eslint-config#main",
-    "@textshq/platform-test-lib": "https://github.com/TextsHQ/platform-test-lib#main",
+    "@textshq/platform-test-lib": "git+ssh://git@github.com:TextsHQ/platform-test-lib#main",
     "@types/better-sqlite3": "^7.6.5",
     "@types/bun": "^1.0.0",
     "@types/eslint": "^8.21.3",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@textshq/eslint-config": "https://github.com/TextsHQ/eslint-config#main",
+    "@textshq/platform-test-lib": "https://github.com/TextsHQ/platform-test-lib#main",
     "@types/better-sqlite3": "^7.6.5",
     "@types/bun": "^1.0.0",
     "@types/eslint": "^8.21.3",
@@ -49,9 +50,6 @@
     "eslint": "^8.36.0",
     "rimraf": "^5.0.5",
     "typescript": "^5.0.2"
-  },
-  "optionalDependencies": {
-    "@textshq/platform-test-lib": "https://github.com/TextsHQ/platform-test-lib#main"
   },
   "packageManager": "yarn@4.0.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2400,9 +2400,6 @@ __metadata:
     tough-cookie: "npm:^4.1.2"
     typescript: "npm:^5.0.2"
     utf-8-validate: "npm:^6.0.3"
-  dependenciesMeta:
-    "@textshq/platform-test-lib":
-      optional: true
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,7 +2375,7 @@ __metadata:
   dependencies:
     "@textshq/eslint-config": "https://github.com/TextsHQ/eslint-config#main"
     "@textshq/platform-sdk": "https://github.com/TextsHQ/platform-sdk#main"
-    "@textshq/platform-test-lib": "https://github.com/TextsHQ/platform-test-lib#main"
+    "@textshq/platform-test-lib": "git+ssh://git@github.com:TextsHQ/platform-test-lib#main"
     "@types/better-sqlite3": "npm:^7.6.5"
     "@types/bun": "npm:^1.0.0"
     "@types/eslint": "npm:^8.21.3"
@@ -2420,9 +2420,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@textshq/platform-test-lib@https://github.com/TextsHQ/platform-test-lib#main":
+"@textshq/platform-test-lib@git+ssh://git@github.com:TextsHQ/platform-test-lib#main":
   version: 0.1.0
-  resolution: "@textshq/platform-test-lib@https://github.com/TextsHQ/platform-test-lib.git#commit=63e2715470fdb244c7e3c0e6e2b14caf6f63766e"
+  resolution: "@textshq/platform-test-lib@git+ssh://git@github.com:TextsHQ/platform-test-lib#commit=63e2715470fdb244c7e3c0e6e2b14caf6f63766e"
   dependencies:
     "@textshq/platform-sdk": "https://github.com/TextsHQ/platform-sdk#main"
     better-sqlite3: "npm:@signalapp/better-sqlite3@8.7.1"


### PR DESCRIPTION
This way, it can be ignored when installing with `NODE_ENV=production`.

Context https://github.com/TextsHQ/texts-app-desktop/pull/565